### PR TITLE
🔀 Switch to using `set_by_lua`

### DIFF
--- a/src/etc/nginx/nginx.conf.template
+++ b/src/etc/nginx/nginx.conf.template
@@ -203,6 +203,13 @@ http {
     # Root
     # https://github.com/ministryofjustice/analytical-platform-nginx-proxy/blob/main/nginx-proxy/nginx.conf.template#L112
     location / {
+      set_by_lua $analytical_platform_tool 'return "${ANALYTICAL_PLATFORM_TOOL}" ';
+      set_by_lua $auth0_client_id          'return "${AUTH0_CLIENT_ID}" ';
+      set_by_lua $auth0_client_secret      'return "${AUTH0_CLIENT_SECRET}" ';
+      set_by_lua $auth0_tenant_domain      'return "${AUTH0_TENANT_DOMAIN}" ';
+      set_by_lua $logout_url               'return "${LOGOUT_URL}" ';
+      set_by_lua $redirect_domain          'return "${REDIRECT_DOMAIN}" ';
+      set_by_lua $username                 'return "${USERNAME}" ';
       access_by_lua_file /opt/lua-scripts/auth0-login.lua;
 
       # https://github.com/ministryofjustice/analytical-platform-nginx-proxy/blob/main/nginx-proxy/nginx.conf.template#L124-L130

--- a/src/opt/lua-scripts/auth0-login.lua
+++ b/src/opt/lua-scripts/auth0-login.lua
@@ -2,24 +2,15 @@
 local activity = ngx.shared.activity
 local openidc  = require "resty.openidc"
 
---- Load environment variables
-local analytical_platform_tool = os.getenv("ANALYTICAL_PLATFORM_TOOL")
-local auth0_client_id          = os.getenv("AUTH0_CLIENT_ID")
-local auth0_client_secret      = os.getenv("AUTH0_CLIENT_SECRET")
-local auth0_tenant_domain      = os.getenv("AUTH0_TENANT_DOMAIN")
-local logout_url               = os.getenv("LOGOUT_URL")
-local redirect_domain          = os.getenv("REDIRECT_DOMAIN")
-local username                 = os.getenv("USERNAME")
-
 --- Construct URLs
-local discovery_url             = "https://" .. auth0_tenant_domain .. "/.well-known/openid-configuration"
-local redirect_after_logout_uri = "https://" .. auth0_tenant_domain .. "/v2/logout?client_id=" .. auth0_client_id .. "&redirectTo=" .. logout_url
-local redirect_uri              = "https://" .. username .. "-" .. analytical_platform_tool .. "." .. redirect_domain .. "/callback"
+local discovery_url             = "https://" .. ngx.var.auth0_tenant_domain .. "/.well-known/openid-configuration"
+local redirect_after_logout_uri = "https://" .. ngx.var.auth0_tenant_domain .. "/v2/logout?client_id=" .. ngx.var.auth0_client_id .. "&redirectTo=" .. ngx.var.logout_url
+local redirect_uri              = "https://" .. ngx.var.username .. "-" .. ngx.var.analytical_platform_tool .. "." .. ngx.var.redirect_domain .. "/callback"
 
 --- Construct the options for the openidc.authenticate function
 local opts = {
-  client_id                                = auth0_client_id,
-  client_secret                            = auth0_client_secret,
+  client_id                                = ngx.var.auth0_client_id,
+  client_secret                            = ngx.var.auth0_client_secret,
   discovery                                = discovery_url,
   redirect_uri                             = redirect_uri,
   redirect_after_logout_uri                = redirect_after_logout_uri,
@@ -52,7 +43,7 @@ if res then
   end
 
   --- If the user is not the correct user, return a 403 status code
-  if id_token_nickname ~= username then
+  if id_token_nickname ~= ngx.var.username then
     ngx.status = 403
     ngx.say("User forbidden for this application. Please contact the Analytical Platform team.")
     ngx.log(ngx.ERR, "User" .. id_token_nickname .. " is forbidden for this application.")


### PR DESCRIPTION
This pull request:

- Reverts the change of using `os.getenv` back to `set_by_lua` as this doesn't work in NGINX LUA

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>  