### PR TITLE
😞 Use `sed` to render Auth0 config

### DIFF
--- a/src/etc/nginx/nginx.conf.template
+++ b/src/etc/nginx/nginx.conf.template
@@ -203,13 +203,13 @@ http {
     # Root
     # https://github.com/ministryofjustice/analytical-platform-nginx-proxy/blob/main/nginx-proxy/nginx.conf.template#L112
     location / {
-      set_by_lua $analytical_platform_tool 'return "${ANALYTICAL_PLATFORM_TOOL}" ';
-      set_by_lua $auth0_client_id          'return "${AUTH0_CLIENT_ID}" ';
-      set_by_lua $auth0_client_secret      'return "${AUTH0_CLIENT_SECRET}" ';
-      set_by_lua $auth0_tenant_domain      'return "${AUTH0_TENANT_DOMAIN}" ';
-      set_by_lua $logout_url               'return "${LOGOUT_URL}" ';
-      set_by_lua $redirect_domain          'return "${REDIRECT_DOMAIN}" ';
-      set_by_lua $username                 'return "${USERNAME}" ';
+      set_by_lua $analytical_platform_tool 'return "ANALYTICAL_PLATFORM_TOOL" ';
+      set_by_lua $auth0_client_id          'return "AUTH0_CLIENT_ID" ';
+      set_by_lua $auth0_client_secret      'return "AUTH0_CLIENT_SECRET" ';
+      set_by_lua $auth0_tenant_domain      'return "AUTH0_TENANT_DOMAIN" ';
+      set_by_lua $logout_url               'return "LOGOUT_URL" ';
+      set_by_lua $redirect_domain          'return "REDIRECT_DOMAIN" ';
+      set_by_lua $username                 'return "USERNAME" ';
       access_by_lua_file /opt/lua-scripts/auth0-login.lua;
 
       # https://github.com/ministryofjustice/analytical-platform-nginx-proxy/blob/main/nginx-proxy/nginx.conf.template#L124-L130

--- a/src/usr/local/bin/entrypoint.sh
+++ b/src/usr/local/bin/entrypoint.sh
@@ -2,25 +2,44 @@
 
 set -e
 
+# NGINX
 export ERROR_LOG_LEVEL="${ERROR_LOG_LEVEL:-error}"
 export PROXY_LISTEN_ADDRESS="${PROXY_LISTEN_ADDRESS:-"*"}"
 export PROXY_LISTEN_PORT="${PROXY_LISTEN_PORT:-3000}"
 export UPSTREAM_HOST="${UPSTREAM_HOST:-localhost}"
 export UPSTREAM_PORT="${UPSTREAM_PORT:-8080}"
 
+# Auth0
+export ANALYTICAL_PLATFORM_TOOL_ID="${ANALYTICAL_PLATFORM_TOOL_ID:-vscode}"
+export AUTH0_CLIENT_ID="${AUTH0_CLIENT_ID:-notarealclientid}"
+export AUTH0_CLIENT_SECRET="${AUTH0_CLIENT_SECRET:-notarealclientsecret}"
+export AUTH0_TENANT_DOMAIN="${AUTH0_TENANT_DOMAIN:-notarealauth0domain.auth0.com}"
+export LOGOUT_URL="${LOGOUT_URL:-"https://google.com"}"
+export REDIRECT_DOMAIN="${REDIRECT_DOMAIN:-"http://localhost:3000"}"
+export USERNAME="${USERNAME:-analyticalplatform}"
+
 echo "Error log level: ${ERROR_LOG_LEVEL}"
 echo "Proxy address: ${PROXY_LISTEN_ADDRESS}:${PROXY_LISTEN_PORT}"
-echo "Upstream: ${UPSTREAM_HOST}:${UPSTREAM_PORT}"
+echo "Proxy Upstream: ${UPSTREAM_HOST}:${UPSTREAM_PORT}"
 
 echo "Createing NGINX configuration from template"
 cp /etc/nginx/nginx.conf.template /etc/nginx/nginx.conf
 
-echo "Replacing placeholders in NGINX configuration"
+echo "Replacing NGINX settings placeholders in NGINX configuration"
 sed -i "s/ERROR_LOG_LEVEL/${ERROR_LOG_LEVEL}/g" /etc/nginx/nginx.conf
 sed -i "s/PROXY_LISTEN_ADDRESS/${PROXY_LISTEN_ADDRESS}/g" /etc/nginx/nginx.conf
 sed -i "s/PROXY_LISTEN_PORT/${PROXY_LISTEN_PORT}/g" /etc/nginx/nginx.conf
 sed -i "s/UPSTREAM_HOST/${UPSTREAM_HOST}/g" /etc/nginx/nginx.conf
 sed -i "s/UPSTREAM_PORT/${UPSTREAM_PORT}/g" /etc/nginx/nginx.conf
+
+echo "Replacing Auth0 settings placeholders in NGINX configuration"
+sed -i "s/ANALYTICAL_PLATFORM_TOOL_ID/${ANALYTICAL_PLATFORM_TOOL_ID}/g" /etc/nginx/nginx.conf
+sed -i "s/AUTH0_CLIENT_ID/${AUTH0_CLIENT_ID}/g" /etc/nginx/nginx.conf
+sed -i "s/AUTH0_CLIENT_SECRET/${AUTH0_CLIENT_SECRET}/g" /etc/nginx/nginx.conf
+sed -i "s/AUTH0_TENANT_DOMAIN/${AUTH0_TENANT_DOMAIN}/g" /etc/nginx/nginx.conf
+sed -i "s|LOGOUT_URL|${LOGOUT_URL}|g" /etc/nginx/nginx.conf
+sed -i "s|REDIRECT_DOMAIN|${REDIRECT_DOMAIN}|g" /etc/nginx/nginx.conf
+sed -i "s/USERNAME/${USERNAME}/g" /etc/nginx/nginx.conf
 
 echo "Testing NGINX configuration"
 /usr/local/openresty/nginx/sbin/nginx -t -c /etc/nginx/nginx.conf


### PR DESCRIPTION
This pull request:

- Uses sed to render Auth0 config, because NGINX Lua does not return environment variables

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 