### PR TITLE
changed schedule run from 9AM to 7AM and vuln fix

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@aa8abd093cd24a89b8dd2d76b6733d8121c64c52 # v8.0.3
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.grype.yml
+++ b/.grype.yml
@@ -76,3 +76,14 @@ ignore:
   - vulnerability: CVE-2026-45186
     # libexpat 2.7.5-r0 in Alpine base image; fixed in 2.8.1-r0.
     # Accepted: libexpat is not directly invoked by nginx or lua-resty-openidc in this deployment.
+
+  # ============================================================================
+  # Alpine package CVEs (curl/libcurl in OpenResty 1.29.2.5-1-alpine-fat base image)
+  # Fixed versions exist in Alpine repos but are not yet available in the base image layer.
+  # ============================================================================
+  - vulnerability: CVE-2026-5773
+    # curl/libcurl 8.19.0-r0 in Alpine base image; fixed in 8.20.0-r0.
+    # Accepted: curl/libcurl is not directly invoked by nginx or lua-resty-openidc in this deployment.
+  - vulnerability: CVE-2026-6276
+    # curl/libcurl 8.19.0-r0 in Alpine base image; fixed in 8.20.0-r0.
+    # Accepted: curl/libcurl is not directly invoked by nginx or lua-resty-openidc in this deployment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #checkov:skip=CKV_DOCKER_3: Current implementation uses off-the-shelf image from OpenResty which doesn't offer a nonroot variant
 
-# docker.io/openresty/openresty:1.29.2.5-1-alpine-fat
-FROM docker.io/openresty/openresty:1.29.2.5-1-alpine-fat@sha256:6359d16c2cefedc216861e7092d486bb1ff19548abd1aa71e6dc094c82477aee
+# docker.io/openresty/openresty:1.31-alpine-fat
+FROM docker.io/openresty/openresty:1.31-alpine-fat@sha256:427d94fea0c24b099e7891e8d1b7976f6d008e2d427e56bab725c8b8b293795b
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #checkov:skip=CKV_DOCKER_3: Current implementation uses off-the-shelf image from OpenResty which doesn't offer a nonroot variant
 
-# docker.io/openresty/openresty:1.31-alpine-fat
-FROM docker.io/openresty/openresty:1.31-alpine-fat@sha256:427d94fea0c24b099e7891e8d1b7976f6d008e2d427e56bab725c8b8b293795b
+# docker.io/openresty/openresty:1.29.2.5-1-alpine-fat
+FROM docker.io/openresty/openresty:1.29.2.5-1-alpine-fat@sha256:6359d16c2cefedc216861e7092d486bb1ff19548abd1aa71e6dc094c82477aee
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Additional changes
- pinned latest version of scheduled run actions
- added vuln ignore for `CVE-2026-5773` and `CVE-2026-6276`

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.